### PR TITLE
Support wiping volume when they are deleted.

### DIFF
--- a/libvirt/resource_libvirt_cloud_init.go
+++ b/libvirt/resource_libvirt_cloud_init.go
@@ -109,7 +109,7 @@ func resourceCloudInitDiskDelete(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	return volumeDelete(client, key)
+	return volumeDelete(client, key, "")
 }
 
 func resourceCloudInitDiskExists(d *schema.ResourceData, meta interface{}) (bool, error) {

--- a/libvirt/resource_libvirt_coreos_ignition.go
+++ b/libvirt/resource_libvirt_coreos_ignition.go
@@ -92,5 +92,5 @@ func resourceIgnitionDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return volumeDelete(client, key)
+	return volumeDelete(client, key, "")
 }

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -14,6 +14,7 @@ func resourceLibvirtVolume() *schema.Resource {
 		Read:   resourceLibvirtVolumeRead,
 		Delete: resourceLibvirtVolumeDelete,
 		Exists: resourceLibvirtVolumeExists,
+		Update: resourceLibvirtVolumeUpdate,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -61,6 +62,7 @@ func resourceLibvirtVolume() *schema.Resource {
 			"wipe_algorithm": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "",
 			},
 			"xml": {
 				Type:     schema.TypeList,
@@ -362,4 +364,8 @@ func resourceLibvirtVolumeExists(d *schema.ResourceData, meta interface{}) (bool
 	defer volume.Free()
 
 	return true, nil
+}
+
+func resourceLibvirtVolumeUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceLibvirtVolumeUpdate(d, meta)
 }

--- a/libvirt/resource_libvirt_volume.go
+++ b/libvirt/resource_libvirt_volume.go
@@ -58,6 +58,10 @@ func resourceLibvirtVolume() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"wipe_algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"xml": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -338,7 +342,7 @@ func resourceLibvirtVolumeDelete(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf(LibVirtConIsNil)
 	}
 
-	return volumeDelete(client, d.Id())
+	return volumeDelete(client, d.Id(), d.Get("wipe_algorithm").(string))
 }
 
 // resourceLibvirtVolumeExists returns True if the volume resource exists


### PR DESCRIPTION
This prevents the recreation of a volume at the same place of a
preceding one, with access to the underlying volume metadata (partition
table, filesystem, etc.)

This should be backward compatible with the previous implementation: if
no wipe algorithm has been specified, the volume is deleted as before.
Otherwise, the volume is first wiped (this can take a while) then
deleted.